### PR TITLE
Support for compiling multiple source modules

### DIFF
--- a/src/Frontend/Program.cs
+++ b/src/Frontend/Program.cs
@@ -126,7 +126,7 @@ namespace MonC.Frontend
                 for (int i = 0, ilen = module.Functions.Count; i < ilen; ++i) {
                     FunctionDefinitionNode function = module.Functions[i];
                     if (function.IsExported) {
-                        if (!headerModule.AddFunction(function)) {
+                        if (!headerModule.AddUniqueFunction(function)) {
                             ParseError error = new ParseError();
                             error.Message = $"Duplicate function: {function.Name}";
                             errors.Add(error);
@@ -138,7 +138,7 @@ namespace MonC.Frontend
                 for (int i = 0, ilen = module.Enums.Count; i < ilen; ++i) {
                     EnumNode enumNode = module.Enums[i];
                     if (enumNode.IsExported) {
-                        if (!headerModule.AddEnum(enumNode)) {
+                        if (!headerModule.AddUniqueEnum(enumNode)) {
                             ParseError error = new ParseError();
                             error.Message = $"Duplicate enum: {enumNode.Name}";
                             errors.Add(error);

--- a/src/Frontend/Program.cs
+++ b/src/Frontend/Program.cs
@@ -7,6 +7,7 @@ using MonC.Debugging;
 using MonC.DotNetInterop;
 using MonC.IL;
 using MonC.Parsing;
+using MonC.SyntaxTree;
 using MonC.VM;
 
 namespace MonC.Frontend
@@ -80,77 +81,101 @@ namespace MonC.Frontend
 
             foreach (string libraryName in libraryNames) {
                 Assembly lib = Assembly.LoadFile(Path.GetFullPath(libraryName));
-                interopResolver.ImportAssembly(lib, BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Static);
+                interopResolver.ImportAssembly(lib,
+                    BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Static);
             }
 
-            ParseModule interopHeaderModule = interopResolver.CreateHeaderModule();
+            ParseModule headerModule = interopResolver.CreateHeaderModule();
+            List<ParseModule> parseModules = new List<ParseModule>(positionals.Count);
 
-            string? filename = null;
+            for (int fi = 0, filen = positionals.Count; fi < filen; ++fi) {
+                string filename = positionals[fi];
 
-            if (positionals.Count > 0) {
-                filename = positionals[0];
-            }
+                Lexer lexer = new Lexer();
+                List<Token> tokens = new List<Token>();
 
-            Lexer lexer = new Lexer();
-            List<Token> tokens = new List<Token>();
+                string? input;
 
-            string? input;
-
-            if (isInteractive) {
-                WritePrompt();
-                while ((input = Console.ReadLine()) != null) {
-                    LexLine(input, lexer, tokens, verbose: showLex);
+                if (isInteractive) {
                     WritePrompt();
-                }
-            } else {
-                if (filename == null) {
-                    while ((input = Console.In.ReadLine()) != null) {
+                    while ((input = Console.ReadLine()) != null) {
                         LexLine(input, lexer, tokens, verbose: showLex);
+                        WritePrompt();
                     }
                 } else {
-                    filename = Path.GetFullPath(filename);
-                    using StreamReader reader = new StreamReader(filename);
-                    while ((input = reader.ReadLine()) != null) {
-                        LexLine(input, lexer, tokens, verbose: showLex);
+                    if (filename == null) {
+                        while ((input = Console.In.ReadLine()) != null) {
+                            LexLine(input, lexer, tokens, verbose: showLex);
+                        }
+                    } else {
+                        filename = Path.GetFullPath(filename);
+                        using StreamReader reader = new StreamReader(filename);
+                        while ((input = reader.ReadLine()) != null) {
+                            LexLine(input, lexer, tokens, verbose: showLex);
+                        }
                     }
                 }
-            }
 
-            lexer.FinishLex(tokens);
+                lexer.FinishLex(tokens);
 
-            Parser parser = new Parser();
-            List<ParseError> errors = new List<ParseError>();
-            ParseModule module = parser.Parse(filename, tokens, interopHeaderModule, errors);
+                Parser parser = new Parser();
+                List<ParseError> errors = new List<ParseError>();
+                ParseModule module = parser.Parse(filename, tokens, errors);
 
-            for (int i = 0, ilen = errors.Count; i < ilen; ++i) {
-                ParseError error = errors[i];
-                Console.Error.WriteLine($"{error.Start.Line + 1},{error.Start.Column + 1}: {error.Message}");
-            }
-
-            if (showAST) {
-                PrintTreeVisitor treeVisitor = new PrintTreeVisitor();
+                // Export functions of all modules before any CodeGen tools run
                 for (int i = 0, ilen = module.Functions.Count; i < ilen; ++i) {
-                    module.Functions[i].AcceptTopLevelVisitor(treeVisitor);
+                    FunctionDefinitionNode function = module.Functions[i];
+                    if (function.IsExported) {
+                        headerModule.Functions.Add(function);
+                    }
                 }
-            }
 
-            if (errors.Count > 0 && !forceCodegen) {
-                Environment.Exit(1);
-            }
+                // Export enums of all modules before any CodeGen tools run
+                for (int i = 0, ilen = module.Enums.Count; i < ilen; ++i) {
+                    EnumNode enumNode = module.Enums[i];
+                    if (enumNode.IsExported) {
+                        headerModule.Enums.Add(enumNode);
+                    }
+                }
 
-            CodeGenerator generator = new CodeGenerator();
-            ILModule ilmodule = generator.Generate(module);
-            if (showIL) {
-                ilmodule.WriteListing(Console.Out);
-            }
-
-            if (errors.Count > 0) {
-                Environment.Exit(1);
+                parseModules.Add(module);
             }
 
             List<LinkError> linkErrors = new List<LinkError>();
             Linker linker = new Linker(linkErrors);
-            linker.AddModule(ilmodule, export: true);
+
+            foreach (ParseModule module in parseModules) {
+                List<ParseError> errors = new List<ParseError>();
+                module.RunSemanticAnalysis(headerModule, errors);
+
+                for (int i = 0, ilen = errors.Count; i < ilen; ++i) {
+                    ParseError error = errors[i];
+                    Console.Error.WriteLine($"{error.Start.Line + 1},{error.Start.Column + 1}: {error.Message}");
+                }
+
+                if (showAST) {
+                    PrintTreeVisitor treeVisitor = new PrintTreeVisitor();
+                    for (int i = 0, ilen = module.Functions.Count; i < ilen; ++i) {
+                        module.Functions[i].AcceptTopLevelVisitor(treeVisitor);
+                    }
+                }
+
+                if (errors.Count > 0 && !forceCodegen) {
+                    Environment.Exit(1);
+                }
+
+                CodeGenerator generator = new CodeGenerator();
+                ILModule ilmodule = generator.Generate(module);
+                if (showIL) {
+                    ilmodule.WriteListing(Console.Out);
+                }
+
+                if (errors.Count > 0) {
+                    Environment.Exit(1);
+                }
+
+                linker.AddModule(ilmodule, export: true);
+            }
 
             foreach (Binding binding in interopResolver.Bindings) {
                 linker.AddFunctionBinding(binding.Prototype.Name, binding.Implementation, export: false);
@@ -162,6 +187,7 @@ namespace MonC.Frontend
                 foreach (LinkError error in linkErrors) {
                     Console.Error.WriteLine($"Link error: {error.Message}");
                 }
+
                 Environment.Exit(1);
             }
 
@@ -170,6 +196,7 @@ namespace MonC.Frontend
                 foreach (string error in loadErrors) {
                     Console.Error.WriteLine($"Load error: {error}");
                 }
+
                 Environment.Exit(1);
             }
 
@@ -198,6 +225,7 @@ namespace MonC.Frontend
             if (!success) {
                 Environment.Exit(-1);
             }
+
             Environment.Exit(vm.ReturnValue);
         }
 
@@ -221,7 +249,7 @@ namespace MonC.Frontend
 
         private static void HandleBreak(VirtualMachine vm, Debugger debugger, VMDebugger vmDebugger)
         {
-            while (DebuggerLoop(vm, debugger, vmDebugger)) {}
+            while (DebuggerLoop(vm, debugger, vmDebugger)) { }
         }
 
         private static bool DebuggerLoop(VirtualMachine vm, Debugger debugger, VMDebugger vmDebugger)
@@ -242,16 +270,15 @@ namespace MonC.Frontend
             }
 
             switch (command) {
-                case "reg":
-                    {
-                        StackFrameInfo frame = vm.GetStackFrame(0);
-                        Console.WriteLine($"Function: {frame.Function}, PC: {frame.PC}, A: {vm.ReturnValue}");
-                        string? sourcePath;
-                        int lineNumber;
-                        if (debugger.GetSourceLocation(frame, out sourcePath, out lineNumber)) {
-                            Console.WriteLine($"File: {sourcePath}, Line: {lineNumber + 1}");
-                        }
+                case "reg": {
+                    StackFrameInfo frame = vm.GetStackFrame(0);
+                    Console.WriteLine($"Function: {frame.Function}, PC: {frame.PC}, A: {vm.ReturnValue}");
+                    string? sourcePath;
+                    int lineNumber;
+                    if (debugger.GetSourceLocation(frame, out sourcePath, out lineNumber)) {
+                        Console.WriteLine($"File: {sourcePath}, Line: {lineNumber + 1}");
                     }
+                }
                     break;
 
                 case "read":
@@ -260,27 +287,30 @@ namespace MonC.Frontend
                         if (i % 4 == 0 && i != 0) {
                             Console.WriteLine();
                         }
+
                         Console.Write(memory.Read(i) + "\t");
                     }
+
                     Console.WriteLine();
                     break;
 
-                case "bp":
-                    {
-                        if (args.Length < 2) {
-                            Console.WriteLine("Not enough args");
-                            break;
-                        }
-                        int breakpointLineNumber;
-                        int.TryParse(args[1], out breakpointLineNumber);
-                        StackFrameInfo frame = vm.GetStackFrame(0);
-                        string? sourcePath;
-                        if (!debugger.GetSourceLocation(frame, out sourcePath, out _)) {
-                            sourcePath = "";
-                        }
-                        Console.WriteLine($"Assuming source file is {sourcePath}");
-                        debugger.SetBreakpoint(sourcePath!, breakpointLineNumber - 1);
+                case "bp": {
+                    if (args.Length < 2) {
+                        Console.WriteLine("Not enough args");
+                        break;
                     }
+
+                    int breakpointLineNumber;
+                    int.TryParse(args[1], out breakpointLineNumber);
+                    StackFrameInfo frame = vm.GetStackFrame(0);
+                    string? sourcePath;
+                    if (!debugger.GetSourceLocation(frame, out sourcePath, out _)) {
+                        sourcePath = "";
+                    }
+
+                    Console.WriteLine($"Assuming source file is {sourcePath}");
+                    debugger.SetBreakpoint(sourcePath!, breakpointLineNumber - 1);
+                }
                     break;
 
                 case "over":

--- a/src/Frontend/Program.cs
+++ b/src/Frontend/Program.cs
@@ -126,7 +126,11 @@ namespace MonC.Frontend
                 for (int i = 0, ilen = module.Functions.Count; i < ilen; ++i) {
                     FunctionDefinitionNode function = module.Functions[i];
                     if (function.IsExported) {
-                        headerModule.Functions.Add(function);
+                        if (!headerModule.AddFunction(function)) {
+                            ParseError error = new ParseError();
+                            error.Message = $"Duplicate function: {function.Name}";
+                            errors.Add(error);
+                        }
                     }
                 }
 
@@ -134,8 +138,21 @@ namespace MonC.Frontend
                 for (int i = 0, ilen = module.Enums.Count; i < ilen; ++i) {
                     EnumNode enumNode = module.Enums[i];
                     if (enumNode.IsExported) {
-                        headerModule.Enums.Add(enumNode);
+                        if (!headerModule.AddEnum(enumNode)) {
+                            ParseError error = new ParseError();
+                            error.Message = $"Duplicate enum: {enumNode.Name}";
+                            errors.Add(error);
+                        }
                     }
+                }
+
+                for (int i = 0, ilen = errors.Count; i < ilen; ++i) {
+                    ParseError error = errors[i];
+                    Console.Error.WriteLine($"{error.Start.Line + 1},{error.Start.Column + 1}: {error.Message}");
+                }
+
+                if (errors.Count > 0 && !forceCodegen) {
+                    Environment.Exit(1);
                 }
 
                 parseModules.Add(module);

--- a/src/MonC/Compiler.cs
+++ b/src/MonC/Compiler.cs
@@ -30,7 +30,8 @@ namespace MonC
             }
 
             Parser parser = new Parser();
-            ParseModule outputModule = parser.Parse(filename, tokens, headerModule, errors);
+            ParseModule outputModule = parser.Parse(filename, tokens, errors);
+            outputModule.RunSemanticAnalysis(headerModule, errors);
 
             if (errors.Count > 0) {
                 return null;

--- a/src/MonC/Parsing/ParseModule.cs
+++ b/src/MonC/Parsing/ParseModule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using MonC.Semantics;
 using MonC.SyntaxTree;
 
 namespace MonC.Parsing
@@ -8,5 +9,11 @@ namespace MonC.Parsing
         public readonly List<FunctionDefinitionNode> Functions = new List<FunctionDefinitionNode>();
         public readonly List<EnumNode> Enums = new List<EnumNode>();
         public readonly Dictionary<ISyntaxTreeNode, Symbol> TokenMap = new Dictionary<ISyntaxTreeNode, Symbol>();
+
+        public void RunSemanticAnalysis(ParseModule headerModule, IList<ParseError> errors)
+        {
+            SemanticAnalyzer analyzer = new SemanticAnalyzer(errors, TokenMap);
+            analyzer.Analyze(headerModule, this);
+        }
     }
 }

--- a/src/MonC/Parsing/ParseModule.cs
+++ b/src/MonC/Parsing/ParseModule.cs
@@ -10,6 +10,32 @@ namespace MonC.Parsing
         public readonly List<EnumNode> Enums = new List<EnumNode>();
         public readonly Dictionary<ISyntaxTreeNode, Symbol> TokenMap = new Dictionary<ISyntaxTreeNode, Symbol>();
 
+        public bool AddFunction(FunctionDefinitionNode function)
+        {
+            if (Functions.Exists(n => n.Name == function.Name)) {
+                return false;
+            }
+            Functions.Add(function);
+            return true;
+        }
+
+        public bool AddEnum(EnumNode enumNode)
+        {
+            HashSet<string> enumerations = new HashSet<string>();
+            foreach (var enumeration in enumNode.Enumerations) {
+                enumerations.Add(enumeration.Key);
+            }
+            foreach (EnumNode existingEnum in Enums) {
+                foreach (var existingEnumeration in existingEnum.Enumerations) {
+                    if (enumerations.Contains(existingEnumeration.Key)) {
+                        return false;
+                    }
+                }
+            }
+            Enums.Add(enumNode);
+            return true;
+        }
+
         public void RunSemanticAnalysis(ParseModule headerModule, IList<ParseError> errors)
         {
             SemanticAnalyzer analyzer = new SemanticAnalyzer(errors, TokenMap);

--- a/src/MonC/Parsing/ParseModule.cs
+++ b/src/MonC/Parsing/ParseModule.cs
@@ -10,7 +10,7 @@ namespace MonC.Parsing
         public readonly List<EnumNode> Enums = new List<EnumNode>();
         public readonly Dictionary<ISyntaxTreeNode, Symbol> TokenMap = new Dictionary<ISyntaxTreeNode, Symbol>();
 
-        public bool AddFunction(FunctionDefinitionNode function)
+        public bool AddUniqueFunction(FunctionDefinitionNode function)
         {
             if (Functions.Exists(n => n.Name == function.Name)) {
                 return false;
@@ -19,7 +19,7 @@ namespace MonC.Parsing
             return true;
         }
 
-        public bool AddEnum(EnumNode enumNode)
+        public bool AddUniqueEnum(EnumNode enumNode)
         {
             HashSet<string> enumerations = new HashSet<string>();
             foreach (var enumeration in enumNode.Enumerations) {

--- a/src/MonC/Parsing/Parser.cs
+++ b/src/MonC/Parsing/Parser.cs
@@ -23,7 +23,7 @@ namespace MonC
 
         private IDictionary<ISyntaxTreeNode, Symbol> _tokenMap = new Dictionary<ISyntaxTreeNode, Symbol>();
 
-        public ParseModule Parse(string? filePath, IEnumerable<Token> tokens, ParseModule headerModule, IList<ParseError> errors)
+        public ParseModule Parse(string? filePath, IEnumerable<Token> tokens, IList<ParseError> errors)
         {
             _filePath = filePath;
             _tokens.Clear();
@@ -37,9 +37,6 @@ namespace MonC
             while (tokenSource.Peek().Type != TokenType.None) {
                 ParseTopLevelStatement(ref tokenSource, outputModule.Functions, outputModule.Enums);
             }
-
-            SemanticAnalyzer analyzer = new SemanticAnalyzer(errors, _tokenMap);
-            analyzer.Analyze(headerModule, outputModule);
 
             return outputModule;
         }

--- a/src/MonC/Semantics/AssignmentAnalyzer.cs
+++ b/src/MonC/Semantics/AssignmentAnalyzer.cs
@@ -6,7 +6,6 @@ using MonC.SyntaxTree;
 using MonC.SyntaxTree.Nodes;
 using MonC.SyntaxTree.Nodes.Expressions;
 using MonC.SyntaxTree.Nodes.Statements;
-using MonC.SyntaxTree.Util.ChildrenVisitors;
 using MonC.SyntaxTree.Util.Delegators;
 using MonC.SyntaxTree.Util.NoOpVisitors;
 using MonC.SyntaxTree.Util.ReplacementVisitors;
@@ -36,22 +35,8 @@ namespace MonC.Semantics
         {
             _scopeManager.ProcessFunction(function);
 
-            ProcessExpressionReplacementsVisitor expressionReplacementsVisitor = new ProcessExpressionReplacementsVisitor(this);
-            ProcessStatementReplacementsVisitor statementReplacementsVisitor = new ProcessStatementReplacementsVisitor(this);
-
-            // Configure the expression children visitor to use the expression replacements visitor for expressions.
-            SyntaxTreeDelegator expressionChildrenDelegator = new SyntaxTreeDelegator();
-            expressionChildrenDelegator.ExpressionVisitor = expressionReplacementsVisitor;
-            expressionChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            ExpressionChildrenVisitor expressionChildrenVisitor = new ExpressionChildrenVisitor(expressionChildrenDelegator);
-
-            // Configure the statement children visitor to use the expression children visitor when encountering expressions.
-            SyntaxTreeDelegator statementChildrenDelegator = new SyntaxTreeDelegator();
-            statementChildrenDelegator.ExpressionVisitor = expressionChildrenVisitor;
-            statementChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            StatementChildrenVisitor statementChildrenVisitor = new StatementChildrenVisitor(statementChildrenDelegator);
-
-            function.Body.VisitStatements(statementChildrenVisitor);
+            ProcessReplacementsVisitorChain replacementsVisitorChain = new ProcessReplacementsVisitorChain(this);
+            replacementsVisitorChain.ProcessReplacements(function);
         }
 
         public void PrepareToVisit()

--- a/src/MonC/Semantics/EnumManager.cs
+++ b/src/MonC/Semantics/EnumManager.cs
@@ -23,8 +23,10 @@ namespace MonC.Semantics
         public void RegisterEnum(EnumNode node)
         {
             foreach (KeyValuePair<string, int> enumeration in node.Enumerations) {
-                if (_map.ContainsKey(enumeration.Key)) {
-                    _errors.Add(new ParseError { Message = $"Duplicate declaration of symbol ${enumeration}" });
+                if (_map.TryGetValue(enumeration.Key, out EnumNode existingNode)) {
+                    if (!ReferenceEquals(node, existingNode)) {
+                        _errors.Add(new ParseError {Message = $"Duplicate declaration of symbol ${enumeration}"});
+                    }
                     continue;
                 }
                 _map.Add(enumeration.Key, node);

--- a/src/MonC/Semantics/SemanticAnalyzer.cs
+++ b/src/MonC/Semantics/SemanticAnalyzer.cs
@@ -48,8 +48,10 @@ namespace MonC.Semantics
                 _functions.Add(externalFunction.Name, externalFunction);
             }
             foreach (FunctionDefinitionNode function in newModule.Functions) {
-                if (_functions.ContainsKey(function.Name)) {
-                    _errorsToProcess.Add(("Redefinition of function " + function.Name, function));
+                if (_functions.TryGetValue(function.Name, out FunctionDefinitionNode existingFunction)) {
+                    if (!ReferenceEquals(function, existingFunction)) {
+                        _errorsToProcess.Add(("Redefinition of function " + function.Name, function));
+                    }
                 }
                 _functions[function.Name] = function;
             }

--- a/src/MonC/Semantics/TranslateIdentifiersVisitor.cs
+++ b/src/MonC/Semantics/TranslateIdentifiersVisitor.cs
@@ -8,7 +8,6 @@ using MonC.SyntaxTree;
 using MonC.SyntaxTree.Nodes;
 using MonC.SyntaxTree.Nodes.Expressions;
 using MonC.SyntaxTree.Nodes.Statements;
-using MonC.SyntaxTree.Util.ChildrenVisitors;
 using MonC.SyntaxTree.Util.Delegators;
 using MonC.SyntaxTree.Util.NoOpVisitors;
 using MonC.SyntaxTree.Util.ReplacementVisitors;
@@ -56,22 +55,8 @@ namespace MonC.Semantics
         {
             _scopeManager.ProcessFunction(function);
 
-            ProcessExpressionReplacementsVisitor expressionReplacementsVisitor = new ProcessExpressionReplacementsVisitor(this);
-            ProcessStatementReplacementsVisitor statementReplacementsVisitor = new ProcessStatementReplacementsVisitor(this);
-
-            // Configure the expression children visitor to use the expression replacements visitor for expressions.
-            SyntaxTreeDelegator expressionChildrenDelegator = new SyntaxTreeDelegator();
-            expressionChildrenDelegator.ExpressionVisitor = expressionReplacementsVisitor;
-            expressionChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            ExpressionChildrenVisitor expressionChildrenVisitor = new ExpressionChildrenVisitor(expressionChildrenDelegator);
-
-            // Configure the statement children visitor to use the expression children visitor when encountering expressions.
-            SyntaxTreeDelegator statementChildrenDelegator = new SyntaxTreeDelegator();
-            statementChildrenDelegator.ExpressionVisitor = expressionChildrenVisitor;
-            statementChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            StatementChildrenVisitor statementChildrenVisitor = new StatementChildrenVisitor(statementChildrenDelegator);
-
-            function.Body.VisitStatements(statementChildrenVisitor);
+            ProcessReplacementsVisitorChain replacementsVisitorChain = new ProcessReplacementsVisitorChain(this);
+            replacementsVisitorChain.ProcessReplacements(function);
         }
 
         public override void VisitUnknown(IExpressionNode node)

--- a/src/MonC/Semantics/TypeResolver.cs
+++ b/src/MonC/Semantics/TypeResolver.cs
@@ -4,7 +4,6 @@ using MonC.SyntaxTree;
 using MonC.SyntaxTree.Nodes;
 using MonC.SyntaxTree.Nodes.Expressions;
 using MonC.SyntaxTree.Nodes.Specifiers;
-using MonC.SyntaxTree.Util.ChildrenVisitors;
 using MonC.SyntaxTree.Util.Delegators;
 using MonC.SyntaxTree.Util.ReplacementVisitors;
 using MonC.TypeSystem;
@@ -30,25 +29,8 @@ namespace MonC.Semantics
 
         public void Process(FunctionDefinitionNode function)
         {
-            SyntaxTreeDelegator delegator = new SyntaxTreeDelegator();
-            delegator.SpecifierVisitor = this;
-
-            ProcessExpressionReplacementsVisitor expressionReplacementsVisitor = new ProcessExpressionReplacementsVisitor(this);
-            ProcessStatementReplacementsVisitor statementReplacementsVisitor = new ProcessStatementReplacementsVisitor(this);
-
-            // Configure the expression children visitor to use the expression replacements visitor for expressions.
-            SyntaxTreeDelegator expressionChildrenDelegator = new SyntaxTreeDelegator();
-            expressionChildrenDelegator.ExpressionVisitor = expressionReplacementsVisitor;
-            expressionChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            ExpressionChildrenVisitor expressionChildrenVisitor = new ExpressionChildrenVisitor(expressionChildrenDelegator);
-
-            // Configure the statement children visitor to use the expression children visitor when encountering expressions.
-            SyntaxTreeDelegator statementChildrenDelegator = new SyntaxTreeDelegator();
-            statementChildrenDelegator.ExpressionVisitor = expressionChildrenVisitor;
-            statementChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
-            StatementChildrenVisitor statementChildrenVisitor = new StatementChildrenVisitor(statementChildrenDelegator);
-
-            function.Body.VisitStatements(statementChildrenVisitor);
+            ProcessReplacementsVisitorChain replacementsVisitorChain = new ProcessReplacementsVisitorChain(this);
+            replacementsVisitorChain.ProcessReplacements(function);
         }
 
         public ISyntaxTreeVisitor ReplacementVisitor => _replacementDelegator;

--- a/src/MonC/SyntaxTree/Util/ChildrenVisitors/TopLevelStatementChildrenVisitor.cs
+++ b/src/MonC/SyntaxTree/Util/ChildrenVisitors/TopLevelStatementChildrenVisitor.cs
@@ -1,0 +1,29 @@
+﻿using MonC.SyntaxTree.Nodes;
+
+namespace MonC.SyntaxTree.Util.ChildrenVisitors
+{
+    public class TopLevelStatementChildrenVisitor : ITopLevelStatementVisitor
+    {
+        private readonly ISyntaxTreeVisitor _visitor;
+
+        public TopLevelStatementChildrenVisitor(ISyntaxTreeVisitor visitor)
+        {
+            _visitor = visitor;
+        }
+
+        public void VisitEnum(EnumNode node)
+        {
+            _visitor.VisitTopLevelStatement(node);
+        }
+
+        public void VisitFunctionDefinition(FunctionDefinitionNode node)
+        {
+            _visitor.VisitTopLevelStatement(node);
+            _visitor.VisitSpecifier(node.ReturnType);
+            for (int i = 0, ilen = node.Parameters.Length; i < ilen; ++i) {
+                _visitor.VisitStatement(node.Parameters[i]);
+            }
+            _visitor.VisitStatement(node.Body);
+        }
+    }
+}

--- a/src/MonC/SyntaxTree/Util/ReplacementVisitors/ProcessReplacementsVisitorChain.cs
+++ b/src/MonC/SyntaxTree/Util/ReplacementVisitors/ProcessReplacementsVisitorChain.cs
@@ -1,0 +1,58 @@
+﻿using MonC.SyntaxTree.Nodes;
+using MonC.SyntaxTree.Util.ChildrenVisitors;
+using MonC.SyntaxTree.Util.Delegators;
+
+namespace MonC.SyntaxTree.Util.ReplacementVisitors
+{
+    public class ProcessReplacementsVisitorChain
+    {
+        private readonly ExpressionChildrenVisitor _expressionChildrenVisitor;
+        private readonly StatementChildrenVisitor _statementChildrenVisitor;
+        private readonly TopLevelStatementChildrenVisitor _topLevelStatementChildrenVisitor;
+
+        public ProcessReplacementsVisitorChain(IReplacementSource source)
+        {
+            ProcessExpressionReplacementsVisitor expressionReplacementsVisitor =
+                new ProcessExpressionReplacementsVisitor(source);
+            ProcessStatementReplacementsVisitor statementReplacementsVisitor =
+                new ProcessStatementReplacementsVisitor(source);
+            ProcessTopLevelStatementReplacementsVisitor topLevelStatementReplacementsVisitor =
+                new ProcessTopLevelStatementReplacementsVisitor(source);
+
+            // Configure the expression children visitor to use the expression replacements visitor for expressions.
+            SyntaxTreeDelegator expressionChildrenDelegator = new SyntaxTreeDelegator();
+            expressionChildrenDelegator.ExpressionVisitor = expressionReplacementsVisitor;
+            expressionChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
+            _expressionChildrenVisitor = new ExpressionChildrenVisitor(expressionChildrenDelegator);
+
+            // Configure the statement children visitor to use the expression children visitor when encountering expressions.
+            SyntaxTreeDelegator statementChildrenDelegator = new SyntaxTreeDelegator();
+            statementChildrenDelegator.ExpressionVisitor = _expressionChildrenVisitor;
+            statementChildrenDelegator.StatementVisitor = statementReplacementsVisitor;
+            _statementChildrenVisitor = new StatementChildrenVisitor(statementChildrenDelegator);
+
+            // Configure the top-level statement children visitor to use the other visitors.
+            SyntaxTreeDelegator topLevelStatementChildrenDelegator = new SyntaxTreeDelegator();
+            topLevelStatementChildrenDelegator.ExpressionVisitor = _expressionChildrenVisitor;
+            topLevelStatementChildrenDelegator.StatementVisitor = _statementChildrenVisitor;
+            topLevelStatementChildrenDelegator.TopLevelVisitor = topLevelStatementReplacementsVisitor;
+            _topLevelStatementChildrenVisitor =
+                new TopLevelStatementChildrenVisitor(topLevelStatementChildrenDelegator);
+        }
+
+        public void ProcessReplacements(ExpressionNode node)
+        {
+            node.AcceptExpressionVisitor(_expressionChildrenVisitor);
+        }
+
+        public void ProcessReplacements(StatementNode node)
+        {
+            node.AcceptStatementVisitor(_statementChildrenVisitor);
+        }
+
+        public void ProcessReplacements(ITopLevelStatementNode node)
+        {
+            node.AcceptTopLevelVisitor(_topLevelStatementChildrenVisitor);
+        }
+    }
+}

--- a/src/MonC/SyntaxTree/Util/ReplacementVisitors/ProcessTopLevelStatementReplacementsVisitor.cs
+++ b/src/MonC/SyntaxTree/Util/ReplacementVisitors/ProcessTopLevelStatementReplacementsVisitor.cs
@@ -1,0 +1,22 @@
+﻿namespace MonC.SyntaxTree.Util.ReplacementVisitors
+{
+    public class ProcessTopLevelStatementReplacementsVisitor : ITopLevelStatementVisitor
+    {
+        public readonly ReplacementProcessor _processor;
+
+        public ProcessTopLevelStatementReplacementsVisitor(IReplacementSource replacementSource)
+        {
+            _processor = new ReplacementProcessor(replacementSource);
+        }
+
+        public void VisitEnum(EnumNode node) { }
+
+        public void VisitFunctionDefinition(FunctionDefinitionNode node)
+        {
+            node.ReturnType = _processor.ProcessReplacement(node.ReturnType);
+            for (int i = 0, ilen = node.Parameters.Length; i < ilen; ++i) {
+                node.Parameters[i] = _processor.ProcessReplacement(node.Parameters[i]);
+            }
+        }
+    }
+}

--- a/test/multi_module/callee.return.monc
+++ b/test/multi_module/callee.return.monc
@@ -1,0 +1,4 @@
+
+int call_me() {
+    return 0;
+}

--- a/test/multi_module/caller.return.monc
+++ b/test/multi_module/caller.return.monc
@@ -1,0 +1,4 @@
+
+int main() {
+    return call_me();
+}

--- a/test/multi_module/declare.enum.monc
+++ b/test/multi_module/declare.enum.monc
@@ -1,0 +1,5 @@
+
+enum Foo {
+    FOO_A,
+    FOO_B
+}

--- a/test/multi_module/use.enum.monc
+++ b/test/multi_module/use.enum.monc
@@ -1,0 +1,12 @@
+
+int main() {
+    if ((int)FOO_A != 0) {
+        return 1;
+    }
+
+    if ((int)FOO_B != 1) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/testrunner.py
+++ b/testrunner.py
@@ -18,6 +18,17 @@ TERM_ERASE_LINE =  '\033[2K'
 TERM_TEXT_FAIL = f'{TERM_COLOR_RED}FAIL{TERM_COLOR_CLEAR}'
 TERM_TEXT_PASS = f'{TERM_COLOR_GREEN}PASS{TERM_COLOR_CLEAR}'
 
+if sys.platform == "win32":
+    # Get ANSI codes working on newish windows consoles
+    import ctypes
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+    def is_crash(code):
+        return code & 0x80000000
+else:
+    def is_crash(code):
+        return code < 0 or code == 255
+
 
 def main():
 
@@ -108,7 +119,7 @@ def test(path, showall: bool) -> bool:
             status = not status
 
         # Crashes always fail
-        if result.returncode < 0 or result.returncode == 255:
+        if is_crash(result.returncode):
             status = False
 
     sys.stdout.write('\r')

--- a/testrunner.py
+++ b/testrunner.py
@@ -4,8 +4,9 @@ import os
 import subprocess
 import sys
 
-TEST_DIR = os.path.normpath(os.path.join(__file__, '..', 'test'))
-FRONTEND_BINARY = os.path.normpath(os.path.join(__file__, '..', 'src', 'Frontend', 'bin', 'Debug', 'netcoreapp3.1', 'Frontend'))
+REPOSITORY_DIR = os.path.dirname(__file__)
+TEST_DIR = os.path.normpath(os.path.join(REPOSITORY_DIR, 'test'))
+FRONTEND_BINARY = os.path.normpath(os.path.join(REPOSITORY_DIR, 'src', 'Frontend', 'bin', 'Debug', 'netcoreapp3.1', 'Frontend'))
 
 
 TERM_COLOR_RED =   '\033[0;31m'
@@ -26,10 +27,22 @@ def main():
         sys.argv.remove('--showall')
 
     test_files = []
+    multi_files = {}
     for dirpath, dirnames, filenames in os.walk(TEST_DIR):
-        for filename in filenames:
-            if os.path.splitext(filename)[1] == '.monc':
-                test_files.append(os.path.join(dirpath, filename))
+        if os.path.basename(dirpath) != 'multi_module':
+            for filename in filenames:
+                if os.path.splitext(filename)[1] == '.monc':
+                    test_files.append(os.path.join(dirpath, filename))
+        else:
+            for filename in filenames:
+                split_filename = os.path.splitext(filename)
+                if split_filename[1] == '.monc':
+                    split_basename = os.path.splitext(split_filename[0])
+                    filepath = os.path.join(dirpath, filename)
+                    if split_basename[1] in multi_files:
+                        multi_files[split_basename[1]].append(filepath)
+                    else:
+                        multi_files[split_basename[1]] = [filepath]
 
     failed_files = []
 
@@ -37,8 +50,12 @@ def main():
         if not test(path, showall):
             failed_files.append(path)
 
+    for basename, file_list in multi_files.items():
+        if not test(file_list, showall):
+            failed_files.append(file_list)
+
     print('=' * 80)
-    
+
     status = len(failed_files) == 0
 
     if status:
@@ -48,7 +65,7 @@ def main():
         print ('Failed tests:')
         for path in failed_files:
             print(path)
-   
+
     print('=' * 80)
 
     if not status:
@@ -58,24 +75,30 @@ def main():
 def test(path, showall: bool) -> bool:
     sys.stdout.write(f'Testing {path}...')
     sys.stdout.flush()
-    
+
     result = None
 
-    with open(path) as f:
-        args = [FRONTEND_BINARY, path]
-        args.extend(sys.argv[1:])
-        try:
-            result = subprocess.run(
-                    args,
-                    encoding='utf-8',
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    timeout=60)
-        except subprocess.TimeoutExpired:
-            pass
-    
-    filename = os.path.basename(path)
-   
+    if not isinstance(path, list):
+        with open(path) as f:
+            args = [FRONTEND_BINARY, path]
+            filename = os.path.basename(path)
+    else:
+        args = [FRONTEND_BINARY]
+        args.extend(path)
+        filename = os.path.basename(path[0])
+
+    args.extend(sys.argv[1:])
+
+    try:
+        result = subprocess.run(
+            args,
+            encoding='utf-8',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60)
+    except subprocess.TimeoutExpired:
+        pass
+
     status = False
 
     if result:
@@ -99,9 +122,9 @@ def test(path, showall: bool) -> bool:
             print(f'[{TERM_TEXT_PASS}] {path}')
         else:
             print(f'[{TERM_TEXT_FAIL}] {path}')
-        
+
         print('-' * 80)
-        
+
         if result:
             print(f'stdout: \n{result.stdout}')
             print(f'stderr: \n{result.stderr}')


### PR DESCRIPTION
This enables multiple .monc source files (additional positional args) to be linked together into one VM module.

This is accomplished by processing modules in 2 passes:

1. Modules are parsed as normal but semantic analysis is deferred. Any exported functions and enums extend the interop header module in this pass.
2. Semantic analysis is performed on all modules with a fully cross-referencing header module available. Modules are added to the VM linker using the existing API.

Additionally, a `ProcessReplacementsVisitorChain` class is added to reduce repeat code in semantic analysis passes that use replacement visitors.